### PR TITLE
Fix issue with trying to get metadata instance from a wrong class

### DIFF
--- a/sqlalchemy_i18n/builders.py
+++ b/sqlalchemy_i18n/builders.py
@@ -103,9 +103,17 @@ class TranslationTableBuilder(TranslationBuilder):
         if extends is None:
             items.append(self.build_foreign_key())
 
+        for base in self.model.__bases__:
+            if hasattr(base, "metadata"):
+                metadata = base.metadata
+                break
+        else:
+            raise Exception("Unable to find base class with appropriate"
+                            " metadata extension")
+
         return sa.schema.Table(
             extends.name if extends is not None else self.table_name,
-            self.model.__bases__[0].metadata,
+            metadata,
             *items,
             extend_existing=extends is not None
         )


### PR DESCRIPTION
One of my models was using a mixin class/multiple inheritance and the builder only looked at the first base for the metadata class and promptly died noting that the mixin class does not have a metadata property.

Fix this up to look at all bases to try and find the metadata instance to use.
