### PR TITLE
Setup hybrid attributes to the correct attribute on the translation table

### DIFF
--- a/sqlalchemy_i18n/builders.py
+++ b/sqlalchemy_i18n/builders.py
@@ -135,7 +135,7 @@ class HybridPropertyBuilder(TranslationBuilder):
 
     def __call__(self):
         for column in self.model.__translated_columns__:
-            self.assign_attr_getter_setters(column.name)
+            self.assign_attr_getter_setters(column.key)
 
 
 class TranslationModelBuilder(TranslationBuilder):


### PR DESCRIPTION
The column 'name' represents the name of the column in the database.
However, the 'key' attribute represents how the column will be
identified on the Table object. The hybrid attribute needs to be setup 
to point to the key of the translation table rather than the column name.

In most situations the column name works fine since the 'key' value defaults to the name. However, if the key happens to be different than the name, this code would not work, the hybrid_attribute would be setup to point at a column on the table that doesn't exist.
