### PR TITLE
Optional passive deletes

### DIFF
--- a/sqlalchemy_i18n/builders.py
+++ b/sqlalchemy_i18n/builders.py
@@ -192,7 +192,7 @@ class RelationshipBuilder(object):
                 collection_class=attribute_mapped_collection('locale'),
                 comparator_factory=TranslationComparator,
                 cascade='all, delete-orphan',
-                passive_deletes=True,
+                passive_deletes=option(self.parent_cls, 'passive_deletes'),
             ))
 
     def assign_translation_parent(self):

--- a/sqlalchemy_i18n/manager.py
+++ b/sqlalchemy_i18n/manager.py
@@ -15,7 +15,7 @@ class BaseTranslationMixin(object):
     pass
 
 
-def translation_base(parent_cls, base_class_factory=None):
+def translation_base(parent_cls, base_class_factory=None, ondelete='CASCADE'):
     if base_class_factory is None:
         base_class_factory = get_declarative_base
 
@@ -40,7 +40,7 @@ def translation_base(parent_cls, base_class_factory=None):
                             '%s.%s' % (parent_cls.__tablename__, name)
                             for name in names
                         ],
-                        ondelete='CASCADE'
+                        ondelete=ondelete
                     ),
                 )
 

--- a/sqlalchemy_i18n/manager.py
+++ b/sqlalchemy_i18n/manager.py
@@ -67,7 +67,8 @@ class TranslationManager(object):
             'locales': [],
             'auto_create_locales': True,
             'fallback_locale': 'en',
-            'exclude_hybrid_properties': []
+            'exclude_hybrid_properties': [],
+            'passive_deletes': True
         }
 
     def instrument_translation_classes(self, mapper, cls):


### PR DESCRIPTION
Hi,

I am using sqlalchemy-i18n with [gitdb2](https://github.com/matthias-k/gitdb2) (an extension for sqlalchemy that manages a database in a git repository). To do so, I have to make sure that all deletes etc. are propagated through python instead of triggering cascades on the database level, as otherwise these changes cannot be progagated to the git repository, which leads to leftover files of already deleted database rows.

To do so, two things have to be changed: The translation relationships have to be configured not to use passive deletes and the translation table's `ondelete` has to be set to `None`.

This pull request makes this behaviour configurable by
* Adding a config option `passive_deletes` that controls the `passive_deletes` property of the
  translation relationships
* adding a keyword argument `ondelete` to `translation_base` that controls the `ondelete` property of the created table (I found no way to do this via the configuration as well).

All changes are in a way that the default behaviour stays the same.

I would be happy if you would consider merging this pull request back into sqlalchemy-i18n. If you want anything changed first, I will be happy to comply.

Best,
  Matthias