### PR TITLE
Fix for SQLA 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ before_script:
 
 language: python
 python:
-  - 2.6
   - 2.7
-  - 3.3
-  - 3.4
   - 3.5
+  - 3.6
+  - 3.7
+addons:
+  postgresql: "9.5"
 install:
   - pip install -e ".[test]"
 script:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -21,6 +21,8 @@ from sqlalchemy_i18n.manager import BaseTranslationMixin
 
 @sa.event.listens_for(Engine, 'before_cursor_execute')
 def count_sql_calls(conn, cursor, statement, parameters, context, executemany):
+    if not hasattr(conn, 'query_count'):
+        conn.query_count = 0
     conn.query_count += 1
 
 
@@ -34,7 +36,7 @@ sqlalchemy_utils.i18n.get_locale = lambda: 'en'
 
 
 class DeclarativeTestCase(object):
-    engine_uri = 'postgres://postgres@localhost/sqlalchemy_i18n_test'
+    engine_uri = 'postgresql://postgres@localhost/sqlalchemy_i18n_test'
     locales = ['en', 'fi']
     create_tables = True
     configure_mappers = True
@@ -44,6 +46,9 @@ class DeclarativeTestCase(object):
         self.session = Session()
 
     def setup_method(self, method):
+        if not sqlalchemy_utils.database_exists(self.engine_uri):
+            sqlalchemy_utils.create_database(self.engine_uri)
+
         self.engine = create_engine(self.engine_uri)
         # self.engine.echo = True
         self.connection = self.engine.connect()


### PR DESCRIPTION
One last test doesn't pass, I haven't figured it out because I haven't dug into mappers so much for now:


```python
_______________________________________________ TestDeclarative.test_order_by_translation ________________________________________________

self = <tests.test_join_expressions.TestDeclarative object at 0x7f7c0ae87880>

    def test_order_by_translation(self):
        self.session.add(self.Article(name=u'cbc'))
        self.session.add(self.Article(name=u'abc'))
        self.session.add(self.Article(name=u'bbc'))
        self.session.commit()
    
        current_translation = sa.orm.aliased(self.Article.current_translation)
        articles = (
            self.session.query(self.Article)
            .join(current_translation, self.Article.current_translation)
            .options(sa.orm.contains_eager(
                self.Article.current_translation, alias=current_translation)
            )
>           .order_by(current_translation.name)
        ).all()

tests/test_join_expressions.py:32: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[AttributeError("'Mapper' object has no attribute '__name__'") raised in repr()] AliasedClass object at 0x7f7c0ae437f0>
key = 'name'

    def __getattr__(self, key):
        try:
            _aliased_insp = self.__dict__["_aliased_insp"]
        except KeyError:
            raise AttributeError()
        else:
            target = _aliased_insp._target
            # maintain all getattr mechanics
>           attr = getattr(target, key)
E           AttributeError: 'Mapper' object has no attribute 'name'

../../lib/python3.9/site-packages/sqlalchemy/orm/util.py:528: AttributeError
```